### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ the same key, and gets the same response back.
 ## Why
 
 Many apps give you no way to change where they send their requests. A browser on
-claude.ai, or the ChatGPT desktop app, has no setting that points it at a gateway.
+claude.ai or chatgpt.com has no setting that points it at a gateway.
 The only place left to intercept that traffic is on the machine itself, before it
 leaves. aitori decrypts only the hosts you list and leaves the rest alone, and if
 the gateway is unavailable the request still reaches its original destination.


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation-only wording change with no runtime or security impact.
> 
> **Overview**
> **README only:** In the **Why** section, the example of apps that cannot be pointed at a gateway is tightened from “A browser on claude.ai, or the ChatGPT desktop app” to “A browser on claude.ai or chatgpt.com”.
> 
> No product behavior, config, or code paths change—just clearer, shorter copy that emphasizes web surfaces rather than naming the ChatGPT desktop app separately.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 09cb50361a5c557b1b94297c160065139a7fb438. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->